### PR TITLE
feat: automatically merge PRs which pass tests

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,8 @@
+pull_request_rules:
+  - name: automatic merge for Dependabot pull requests
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$- author~=^dependabot(|-preview)\[bot\]$
+      - check-success=build (13.x)
+    actions:
+      merge:
+        method: rebase


### PR DESCRIPTION
Untested because this needs merging and Mergify needs enabling on this repo first, but in theory this should keep the Dependabot PRs dealt with